### PR TITLE
服务消费设置分组

### DIFF
--- a/swagger-dubbo/src/main/java/com/deepoove/swagger/dubbo/http/ReferenceManager.java
+++ b/swagger-dubbo/src/main/java/com/deepoove/swagger/dubbo/http/ReferenceManager.java
@@ -77,6 +77,7 @@ public class ReferenceManager {
                 reference.setRegistries(service.getRegistries());
                 reference.setInterface(service.getInterfaceClass());
                 reference.setVersion(service.getVersion());
+                reference.setGroup(service.getGroup());
                 interfaceMapProxy.put(service.getInterfaceClass(), reference.get());
                 return reference.get();
             }


### PR DESCRIPTION
我认为服务消费设置的分组应该是从本服务中获取的，而非从其他地方获取，这样能够提高服务分组的准确性。